### PR TITLE
unhandled promise from mongo solved

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,13 +9,9 @@ const mongoose = require("mongoose");
 mongoose.connect("mongodb://localhost:27017/FoodDB", {
   useNewUrlParser: true,
   useUnifiedTopology: true,
-});
-
-mongoose.connection.on("connected", () => {
-  console.log("connected to mongo");
-});
-
-mongoose.connection.on("error", (err) => {
+}).then(res => {
+  console.log("connected to mongo: ");
+}).catch(err => {
   console.log("error connecting to mongo", err);
 });
 


### PR DESCRIPTION
This PR deals with the unhandled promise rejection error that keeps appearing in the console when trying to connect to the database. 

There are still errors connecting to the database, which will be handled in another PR.

Essentially MongoDB requires to use the then/catch instead of the mongoose.connection.on method.

The error: 
![Code_yT4vJRYpkY](https://user-images.githubusercontent.com/77639637/139594569-e5e27578-6a12-4d5f-a4c5-d4259aabd3a6.png)
  

After handling the promise: 
![image](https://user-images.githubusercontent.com/77639637/139594588-4c036816-644d-4c21-b403-6fc27a926259.png)
